### PR TITLE
Add rich text editing for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ A simple, animated, and efficient iOS todo app built with SwiftUI.
 - Add and delete tasks with smooth animations
 - Mark tasks as complete or incomplete
 - Tasks are persisted locally using SwiftData
+- Apply bold, italic, underline, or strikethrough to any portion of a task while editing using the keyboard toolbar
+- Formatting appears inline without showing Markdown markers
+- Easily dismiss the keyboard with a toolbar button
 ## Requirements
 - Xcode 15 or later
 - iOS 17 or later

--- a/SimpleTodo2/ContentView.swift
+++ b/SimpleTodo2/ContentView.swift
@@ -7,22 +7,30 @@
 
 import SwiftUI
 import SwiftData
+import UIKit
 
 struct ContentView: View {
     @Environment(\.modelContext) private var context
     @Query private var tasks: [Task]
-    @State private var newTaskTitle = ""
+    @State private var newTaskTitle: NSAttributedString = NSAttributedString(string: "")
+    @State private var selectedRange = NSRange(location: 0, length: 0)
+    @FocusState private var isInputActive: Bool
 
     var body: some View {
         NavigationView {
             VStack {
                 HStack {
-                    TextField("New Task", text: $newTaskTitle)
-                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    RichTextEditor(text: $newTaskTitle, selectedRange: $selectedRange, isFocused: $isInputActive)
+                        .frame(height: 36)
+                        .padding(4)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.secondary)
+                        )
                     Button(action: addTask) {
                         Image(systemName: "plus")
                     }
-                    .disabled(newTaskTitle.isEmpty)
+                    .disabled(newTaskTitle.string.isEmpty)
                 }
                 .padding()
 
@@ -35,14 +43,33 @@ struct ContentView: View {
                 .listStyle(PlainListStyle())
             }
             .navigationTitle("Todos")
+            .toolbar {
+                ToolbarItemGroup(placement: .keyboard) {
+                    Button(action: applyBold) {
+                        Image(systemName: "bold")
+                    }
+                    Button(action: applyItalic) {
+                        Image(systemName: "italic")
+                    }
+                    Button(action: applyUnderline) {
+                        Image(systemName: "underline")
+                    }
+                    Button(action: applyStrikethrough) {
+                        Image(systemName: "strikethrough")
+                    }
+                    Spacer()
+                    Button("Dismiss") { isInputActive = false }
+                }
+            }
         }
     }
 
     private func addTask() {
-        guard !newTaskTitle.isEmpty else { return }
-        let newTask = Task(title: newTaskTitle)
+        guard !newTaskTitle.string.isEmpty else { return }
+        let markdown = (try? AttributedString(newTaskTitle).markdown) ?? newTaskTitle.string
+        let newTask = Task(title: markdown)
         context.insert(newTask)
-        newTaskTitle = ""
+        newTaskTitle = NSAttributedString(string: "")
     }
 
     private func delete(_ offsets: IndexSet) {
@@ -55,6 +82,61 @@ struct ContentView: View {
     private func toggle(_ task: Task) {
         task.isCompleted.toggle()
     }
+
+    private func selectedOrAllRange() -> NSRange {
+        if selectedRange.length > 0 { return selectedRange }
+        return NSRange(location: 0, length: newTaskTitle.length)
+    }
+
+    private func toggleFontTrait(_ trait: UIFontDescriptor.SymbolicTraits) {
+        let range = selectedOrAllRange()
+        let mutable = NSMutableAttributedString(attributedString: newTaskTitle)
+        var shouldAdd = true
+        mutable.enumerateAttribute(.font, in: range) { value, _, stop in
+            if let font = value as? UIFont,
+               font.fontDescriptor.symbolicTraits.contains(trait) {
+                shouldAdd = false
+                stop.pointee = true
+            }
+        }
+        mutable.enumerateAttribute(.font, in: range) { value, subRange, _ in
+            let base = (value as? UIFont) ?? UIFont.preferredFont(forTextStyle: .body)
+            var traits = base.fontDescriptor.symbolicTraits
+            if shouldAdd {
+                traits.insert(trait)
+            } else {
+                traits.remove(trait)
+            }
+            if let descriptor = base.fontDescriptor.withSymbolicTraits(traits) {
+                let newFont = UIFont(descriptor: descriptor, size: base.pointSize)
+                mutable.addAttribute(.font, value: newFont, range: subRange)
+            }
+        }
+        newTaskTitle = mutable
+    }
+
+    private func applyUnderlineStyle(_ style: NSUnderlineStyle, key: NSAttributedString.Key) {
+        let range = selectedOrAllRange()
+        let mutable = NSMutableAttributedString(attributedString: newTaskTitle)
+        var shouldAdd = true
+        mutable.enumerateAttribute(key, in: range) { value, _, stop in
+            if let raw = value as? Int, raw != 0 {
+                shouldAdd = false
+                stop.pointee = true
+            }
+        }
+        if shouldAdd {
+            mutable.addAttribute(key, value: style.rawValue, range: range)
+        } else {
+            mutable.removeAttribute(key, range: range)
+        }
+        newTaskTitle = mutable
+    }
+
+    private func applyBold() { toggleFontTrait(.traitBold) }
+    private func applyItalic() { toggleFontTrait(.traitItalic) }
+    private func applyUnderline() { applyUnderlineStyle(.single, key: .underlineStyle) }
+    private func applyStrikethrough() { applyUnderlineStyle(.single, key: .strikethroughStyle) }
 }
 
 struct TaskRow: View {
@@ -65,9 +147,20 @@ struct TaskRow: View {
         HStack {
             Image(systemName: task.isCompleted ? "checkmark.circle.fill" : "circle")
                 .onTapGesture(perform: toggle)
-            Text(task.title)
+            formattedText(for: task.title)
                 .strikethrough(task.isCompleted)
                 .foregroundColor(task.isCompleted ? .gray : .primary)
+        }
+    }
+
+    private func formattedText(for text: String) -> Text {
+        if let attributed = try? AttributedString(
+            markdown: text,
+            options: .init(interpretedSyntax: .full)
+        ) {
+            return Text(attributed)
+        } else {
+            return Text(text)
         }
     }
 }

--- a/SimpleTodo2/RichTextEditor.swift
+++ b/SimpleTodo2/RichTextEditor.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct RichTextEditor: UIViewRepresentable {
+    @Binding var text: NSAttributedString
+    @Binding var selectedRange: NSRange
+    @Binding var isFocused: Bool
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIView(context: Context) -> UITextView {
+        let tv = UITextView()
+        tv.delegate = context.coordinator
+        tv.isScrollEnabled = false
+        tv.font = UIFont.preferredFont(forTextStyle: .body)
+        tv.backgroundColor = .clear
+        return tv
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        if uiView.attributedText != text {
+            uiView.attributedText = text
+        }
+        if uiView.selectedRange != selectedRange {
+            uiView.selectedRange = selectedRange
+        }
+        if isFocused && !uiView.isFirstResponder {
+            uiView.becomeFirstResponder()
+        } else if !isFocused && uiView.isFirstResponder {
+            uiView.resignFirstResponder()
+        }
+    }
+
+    class Coordinator: NSObject, UITextViewDelegate {
+        var parent: RichTextEditor
+        init(_ parent: RichTextEditor) {
+            self.parent = parent
+        }
+        func textViewDidChange(_ textView: UITextView) {
+            parent.text = textView.attributedText
+        }
+        func textViewDidChangeSelection(_ textView: UITextView) {
+            parent.selectedRange = textView.selectedRange
+        }
+        func textViewDidBeginEditing(_ textView: UITextView) {
+            parent.isFocused = true
+        }
+        func textViewDidEndEditing(_ textView: UITextView) {
+            parent.isFocused = false
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `RichTextEditor` component to allow selecting ranges
- support bold, italic, underline and strikethrough formatting on selected text
- show formatted text inline while editing
- update README for new formatting behavior

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840a496f9bc8326ada0159b9429cb04